### PR TITLE
added the capability to specify a log file path

### DIFF
--- a/R/loadTaxonomy.R
+++ b/R/loadTaxonomy.R
@@ -5,6 +5,7 @@
 #' @param sample_id Field in reference taxonomy that defines the sample_id.
 #' @param hGenes User supplied variable gene vector.  If not provided, then all genes are used.
 #' @param gene_id Field in counts.feather that defines the gene_id.
+#' @param log.file.path Path to write log file to. Defaults to current working directory. 
 #' @param force Force rebuild the anndata object for the taxonomy.
 #'
 #' @return Organized reference object ready for mapping against.
@@ -15,6 +16,7 @@ loadTaxonomy = function(taxonomyDir,
                         sample_id = "sample_id", 
                         hGenes=NULL, 
                         gene_id = "gene",
+                        log.file.path=getwd(),
                         force=FALSE){
 
   ## Load from directory name input 
@@ -35,8 +37,8 @@ loadTaxonomy = function(taxonomyDir,
       }))
     }
     ## Ensure anndata is in scrattch.mapping format
-    if(!checkTaxonomy(AIT.anndata,taxonomyDir)){
-     stop(paste("Taxonomy has some breaking issues.  Please check checkTaxonomy_log.txt in", taxonomyDir, "for details"))
+    if(!checkTaxonomy(AIT.anndata,log.file.path)){
+     stop(paste("Taxonomy has some breaking issues.  Please check checkTaxonomy_log.txt in", log.file.path, "for details"))
     }
   } else if(all(file.exists(c(file.path(taxonomyDir,"anno.feather"), 
                               file.path(taxonomyDir,"data.feather"), 


### PR DESCRIPTION
When calling `loadTaxonomy` using a h5ad file located in an S3 bucket, the following error occurs because it tries to write to the directory where the taxonomy is located:

``` 
> AIT.anndata = loadTaxonomy(taxonomyDir = '../data/taxonomies/Taxonomies/AIT21.0_mouse', anndata_file="HANN.AIT21.0.h5ad")
[1] "Loading reference taxonomy into memory from .h5ad"
Error in file(file, ifelse(append, "a", "w")) : 
  cannot open the connection
In addition: Warning message:
In file(file, ifelse(append, "a", "w")) :
  cannot open file '/data/taxonomies/Taxonomies/AIT21.0_mouse/checkTaxonomy_log.txt': Read-only file system
```

This PR is to allow a user to specify a log file location that differs from the taxonomy file location. 