### PR TITLE
Jeremy scrattch1p1p2 update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scrattch.taxonomy
 Title: Generalized Allen Institute taxonomy building.
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: 
     person(given = "Nelson",
            family = "Johansen",

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,16 +81,16 @@ RUN pip install -e ./cell_type_mapper
 RUN pip install anndata==0.8.0 numpy==1.26.4 
 
 ## scrattch-taxonomy install from local source
-COPY scrattch.taxonomy_1.1.1.tar.gz ./scrattch.taxonomy_1.1.1.tar.gz
-RUN R -e 'install.packages("scrattch.taxonomy_1.1.1.tar.gz", repos=NULL, type="source")'
+COPY scrattch.taxonomy_1.1.2.tar.gz ./scrattch.taxonomy_1.1.2.tar.gz
+RUN R -e 'install.packages("scrattch.taxonomy_1.1.2.tar.gz", repos=NULL, type="source")'
 
 ## scrattch-mapping install from local source
 COPY scrattch.mapping_0.7.1.tar.gz ./scrattch.mapping_0.7.1.tar.gz
 RUN R -e 'install.packages("scrattch.mapping_0.7.1.tar.gz", repos=NULL, type="source")'
 
 # ## scrattch-patchseq install from local source
-COPY scrattch.patchseq_0.1.1.tar.gz ./scrattch.patchseq_0.1.1.tar.gz
-RUN R -e 'install.packages("scrattch.patchseq_0.1.1.tar.gz", repos=NULL, type="source")'
+COPY scrattch.patchseq_1.1.2.tar.gz ./scrattch.patchseq_1.1.2.tar.gz
+RUN R -e 'install.packages("scrattch.patchseq_1.1.2.tar.gz", repos=NULL, type="source")'
 
 ## 
 RUN R -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/matrixStats/matrixStats_1.1.0.tar.gz", repos=NULL, type="source")'

--- a/R/buildTaxonomyMode.R
+++ b/R/buildTaxonomyMode.R
@@ -197,15 +197,6 @@ buildTaxonomyMode = function(AIT.anndata,
   ## MAPMYCELLS FUNCTIONALITY
   
   ## Add MapMyCells (hierarchical mapping) functionality, if requested
-  #if(addMapMyCells) {
-  #  current.mode = AIT.anndata$uns$mode
-  #  AIT.anndata  = mappingMode(AIT.anndata, mode=mode.name)
-  #  AIT.anndata  = addMapMyCells(AIT.anndata, hierarchy, force=TRUE)
-  #  AIT.anndata  = mappingMode(AIT.anndata, mode=current.mode)
-  #  # NOTE: statistics used to be saved in 'uns', but are being moved to 'varm'
-  #}
-  
-  ## Add MapMyCells (hierarchical mapping) functionality, if requested
   if(addMapMyCells) {
     print("===== Adding MapMyCells (hierarchical mapping) functionality =====")
     tryCatch({
@@ -219,12 +210,12 @@ buildTaxonomyMode = function(AIT.anndata,
     })
   }
   
-  
-  
-  ## If not yet written in add.dendrogram.markers or addMapMyCells, write h5ad
-  if(!(addMapMyCells|add.dendrogram.markers)){
-    AIT.anndata$write_h5ad(file.path(AIT.anndata$uns$taxonomyDir, paste0(AIT.anndata$uns$title, ".h5ad")))
-  }
+  ## Write the Allen Institute Taxonomy object without the normalized data (it can be recalculated on load)
+  print("===== Writing taxonomy anndata without saved normalized data=====")
+  AIT.anndata2 = AIT.anndata
+  AIT.anndata2$X = NULL
+  AIT.anndata2$write_h5ad(file.path(AIT.anndata2$uns$taxonomyDir, paste0(AIT.anndata2$uns$title, ".h5ad")))
+  rm(AIT.anndata2)
   
   ##
   return(AIT.anndata)

--- a/R/checkTaxonomy.R
+++ b/R/checkTaxonomy.R
@@ -666,7 +666,6 @@ checkMetadata = function(meta.data, schema, messages=c(), isValid=FALSE, isWarni
 
       ## Now check that each embedding is what we would expect
       if((class(dim(AIT.anndata$obsm[[embedding]])) != "integer") | 
-          (class(AIT.anndata$obsm[[embedding]])[1]=="data.frame") |
           (!is.element(class(AIT.anndata$obsm[[embedding]][1,1]), c("integer","numeric","character")))){
         isWarning = TRUE
         messages = c(messages, paste0("\nWARNING: An embedding: ", embedding, " is invalid."))

--- a/R/checkTaxonomy.R
+++ b/R/checkTaxonomy.R
@@ -395,7 +395,7 @@ checkTaxonomy = function(AIT.anndata,
   # Now do the test
   if(column_def$Key == "anatomical_region_ontology_term_id"){
     if(!all(column %in% uberon)){
-      messages = c(messages, paste0("\nERROR: The anndata.obs element: ", column_def$Key, " must all be valid NCBITaxons."))
+      messages = c(messages, paste0("\nERROR: The anndata.obs element: ", column_def$Key, " must all be valid UBERON terms."))
       isValid = FALSE
     }
   }

--- a/R/loadTaxonomy.R
+++ b/R/loadTaxonomy.R
@@ -46,6 +46,12 @@ loadTaxonomy = function(taxonomyDir,
   }else{
     stop("Required files to load Allen Institute taxonomy are missing.")
   }
+  
+  ## If counts are included but normalized counts are not, calculate normalized counts
+  if((!is.null(AIT.anndata$raw$X))&(is.null(AIT.anndata$X))){
+    normalized.expr = log2CPM_byRow(AIT.anndata$raw$X)
+    AIT.anndata$X   = normalized.expr 
+  }
 
   ## Set scrattch.mapping to default standard mapping mode
   AIT.anndata$uns$mode = "standard"

--- a/R/updateTaxonomyMetadata.R
+++ b/R/updateTaxonomyMetadata.R
@@ -207,8 +207,8 @@ updateTaxonomyMetadata = function(metadata,
     if(column.name %in% schema.columns){
       out = as.character(metadata[,column.name])  # will convert back to factor later
       metadata[,column.name] <- firsttolower(metadata[,column.name])
-      if(sum(metadata[,column.name]!=out)>0){
-        kp       = metadata[,column.name]!=out
+      kp  = tolower(metadata[,column.name])!=tolower(out)
+      if(sum(kp)>0){
         updates  = paste(unique(paste(out[kp],metadata[kp,column.name],sep="->")),collapse=", ")
         messages = c(messages, paste0("\nWARNING: some updates to anatomical_region: ",updates))
       }
@@ -312,10 +312,12 @@ updateTaxonomyMetadata = function(metadata,
           ## Add a new column to the metadata table for the ontology ID terms
           metadata[,paste0(onto_term,"_ontology_term_id")] = ontology_conversion$id
           ## Report any changed names
-          if(sum(ontology_conversion$distance)>0){
+          reported_match = tolower(ontology_conversion[,4])==tolower(ontology_conversion[,2])
+          reported_match = reported_match|(sum(ontology_conversion$distance)==0)
+          if(sum(!reported_match)>0){
             change <- paste0(ontology_conversion[,1],"('",ontology_conversion[,4],"'==>'",ontology_conversion[,2],"')")
             messages = c(messages, paste0("\nWARNING: the following ontology terms do not correspond perfectly with inputted values:\n"))
-            messages = c(messages, paste0("-----",paste(sort(unique(change[ontology_conversion$distance>0])),collapse="\n-----")))
+            messages = c(messages, paste0("-----",paste(sort(unique(change[!reported_match])),collapse="\n-----")))
           }
         }
       } else {
@@ -367,10 +369,12 @@ updateTaxonomyMetadata = function(metadata,
       ## Add a new column to the metadata table for the ontology ID terms
       metadata[,"brain_region_ontology_term_id"] = ontology_conversion$id
       ## Report any changed names
-      if(sum(ontology_conversion$distance)>0){
+      reported_match = tolower(ontology_conversion[,4])==tolower(ontology_conversion[,2])
+      reported_match = reported_match|(sum(ontology_conversion$distance)==0)
+      if(sum(!reported_match)>0){
         change <- paste0(ontology_conversion[,1],"('",ontology_conversion[,4],"'==>'",ontology_conversion[,2],"')")
         messages = c(messages, paste0("\nWARNING: the following ontology terms do not correspond perfectly with inputted values:\n"))
-        messages = c(messages, paste0("-----",paste(sort(unique(change[ontology_conversion$distance>0])),collapse="\n-----")))
+        messages = c(messages, paste0("-----",paste(sort(unique(change[!reported_match])),collapse="\n-----")))
       }
     }
   }
@@ -403,10 +407,12 @@ updateTaxonomyMetadata = function(metadata,
         ## Add a new column to the metadata table for the ontology ID terms
         metadata[,"cell_type_ontology_term"] = ontology_conversion$id
         ## Report any changed names
-        if(sum(ontology_conversion$distance)>0){
+        reported_match = tolower(ontology_conversion[,4])==tolower(ontology_conversion[,2])
+        reported_match = reported_match|(sum(ontology_conversion$distance)==0)
+        if(sum(!reported_match)>0){
           change <- paste0(ontology_conversion[,1],"('",ontology_conversion[,4],"'==>'",ontology_conversion[,2],"')")
           messages = c(messages, paste0("\nWARNING: the following ontology terms do not correspond perfectly with inputted values:\n"))
-          messages = c(messages, paste0("-----",paste(sort(unique(change[ontology_conversion$distance>0])),collapse="\n-----")))
+          messages = c(messages, paste0("-----",paste(sort(unique(change[!reported_match])),collapse="\n-----")))
         }
       }
     } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -286,9 +286,12 @@ updateMarkerGenes = function(AIT.anndata,
   }
 
   ## Now check the dendrogram clusters and formatting, if dendrogram is provided
-  if(!is.null(dend)){
+  if((!is.null(dend))&(!all(is.na(dend)))){
     ## Check that dend is of class dendrogram
     if(!is.element("dendrogram",class(dend))){stop("If provided, dend must be of R class dendrogram.")}
+    
+    ## Check that dend is a binary tree (conversion to JSON only works for binary trees)
+    if(is.element("try-error",class(try(as.hclust(dend))))){stop("If provided, dend must be a binary tree.")}
 
     ## Check that dend and meta.data match in labels
     extra_labels <- setdiff(labels(dend), unique(as.character(meta.data[,celltypeColumn])))
@@ -336,7 +339,7 @@ updateMarkerGenes = function(AIT.anndata,
 subsample_taxonomy = function(cluster.names, cell_ids, dend=NULL, subsample=2000){
   
   kpClusters <- rep(TRUE,length(cluster.names))
-  if(!is.null(dend)){
+  if((!is.null(dend))&(!all(is.na(dend)))){
     kpClusters <- is.element(cluster.names, labels(dend)) # exclude missing clusters, if any
     if(mean(kpClusters)<1) print("===== Omitting cells from missing clusters =====")
   }
@@ -422,7 +425,9 @@ mappingMode <- function(AIT.anndata, mode){
 #' 
 #' @export
 dend_to_json = function(dend){
-    # Convert dendrogram to hclust
+    ## Return NULL if NULL is provided
+    if (is.null(dend)) return(NULL)
+    ## Convert dendrogram to hclust
     hclust_obj <- as.hclust(dend)
     ## Record information in list
     dendrogram_json <- list(
@@ -450,7 +455,10 @@ dend_to_json = function(dend){
 #' @export
 json_to_dend = function(json){
     ## 
-    hclust.tmp <- list()  # initialize empty object
+    if(is.null(json)) return(NULL)  # Return NULL if NULL is provided
+    if(nchar(json)<5) return(NULL)  # Return NULL if a blank json is provided 
+  
+  hclust.tmp <- list()  # initialize empty object
     # define merging pattern: 
     #    negative numbers are leaves, 
     #    positive are merged clusters (defined by row number in $merge)

--- a/R/utils.R
+++ b/R/utils.R
@@ -273,7 +273,7 @@ updateMarkerGenes = function(AIT.anndata,
                                       title, 
                                       dend){
   if(sum(is.element(celltypeColumn, colnames(meta.data)))==0){stop("cluster column must be defined in the meta.data object")}
-  if(!all(colnames(counts) == rownames(meta.data))){stop("Colnames of `counts` and rownames of `meta.data` do not match.")}
+  if(!all(rownames(counts) == rownames(meta.data))){stop("Colnames of `counts` and rownames of `meta.data` do not match.")}
   if(!is.data.frame(meta.data)){stop("meta.data must be a data.frame, convert using as.data.frame(meta.data)")}
 
   ## Sanity checks on data matrices
@@ -281,7 +281,7 @@ updateMarkerGenes = function(AIT.anndata,
     if(!is(counts, 'sparseMatrix')){stop("`counts` must be a sparse matrix.")}
     if(!is.null(normalized.expr)){
       if(!is(normalized.expr, 'sparseMatrix')){stop("`normalized.expr` must be a sparse matrix.")}
-      if(!all(rownames(counts) == rownames(normalized.expr))){stop("Rownames of `counts` and `normalized.expr` do not match.")}
+      if(!all(colnames(counts) == colnames(normalized.expr))){stop("Rownames of `counts` and `normalized.expr` do not match.")}
     }
   }
 
@@ -305,7 +305,7 @@ updateMarkerGenes = function(AIT.anndata,
   if(!is.null(cluster_stats)){
     print("===== Checking cluster_stats =====")
     if(!is.null(counts)){
-      if(!all(rownames(cluster_stats) %in% rownames(counts))){
+      if(!all(rownames(cluster_stats) %in% colnames(counts))){
         stop("Cluster stats must have the same columns as the normalized expression matrix.")
       }
     }

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,18 @@
+## scrattch.taxonomy v1.1.2
+
+Update to allow counts to be provided as cellxgene or genexcell.
+
+### Major changes
+* Creation of logCPM_byRows to allow counts to be input as cellxgene or genexcell and to avoid multiple large matrix transpositions
+* Update loadTaxonomy to auto-calulate normalized counts so these don't need to be saved in h5ad files
+
+### Minor changes
+* A few additional bug fixes from v1.1.1
+* Minor updates to the MTG example 
+
+
+--
+
 ## scrattch.taxonomy v1.1.1
 
 Update to better integrate the Allen Institute schema and downstream scrattch.mapping and scrattch.patchseq functionality.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,10 +5,12 @@ Update to allow counts to be provided as cellxgene or genexcell.
 ### Major changes
 * Creation of logCPM_byRows to allow counts to be input as cellxgene or genexcell and to avoid multiple large matrix transpositions
 * Update loadTaxonomy to auto-calulate normalized counts so these don't need to be saved in h5ad files
+* Addition of a gene.meta.data slot in buildTaxonomy for gene information
 
 ### Minor changes
 * A few additional bug fixes from v1.1.1
 * Minor updates to the MTG example 
+* Output additional warnings when metadata is changed with updateTaxonomyMetadata
 
 
 --

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,6 +6,7 @@ Update to allow counts to be provided as cellxgene or genexcell.
 * Creation of logCPM_byRows to allow counts to be input as cellxgene or genexcell and to avoid multiple large matrix transpositions
 * Update loadTaxonomy to auto-calulate normalized counts so these don't need to be saved in h5ad files
 * Addition of a gene.meta.data slot in buildTaxonomy for gene information
+* Improve treatment of dendrograms (precomputed dendrograms were being ignored and non-ideal genes were being used to compute)
 
 ### Minor changes
 * A few additional bug fixes from v1.1.1

--- a/examples/build_MTG_taxonomy.md
+++ b/examples/build_MTG_taxonomy.md
@@ -126,6 +126,7 @@ AIT.anndata = buildTaxonomyMode(AIT.anndata,
                                 highly_variable_genes = 1000,
                                 embeddings = "highly_variable_genes_neurons",
                                 retain.cells = neuron.cells, 
+                                add.dendrogram.markers = TRUE,  # Very slow, but required for downstream patch-seq analysis.
                                 subsample = 100, 
                                 overwrite = TRUE)
 ```

--- a/examples/build_MTG_taxonomy.md
+++ b/examples/build_MTG_taxonomy.md
@@ -41,10 +41,6 @@ taxonomy.metadata = seaad_data$obs[keepCells,cn]
 ## Ensure count matrix and annotations are in the same order (this shouldn't be needed)
 taxonomy.metadata = taxonomy.metadata[match(rownames(taxonomy.counts), taxonomy.metadata$sample_name),]
 colnames(taxonomy.metadata) <- gsub("_label","",colnames(taxonomy.metadata))
-
-## Transpose the counts matrix (... for now; future versions of scrattch.taxonomy will not need to transpose large matrices)
-taxonomy.counts <- t(taxonomy.counts)
-taxonomy.counts <- as(taxonomy.counts, "dgCMatrix")
 ```
 
 #### Align to AIT schema
@@ -93,7 +89,7 @@ AIT.anndata = buildTaxonomy(title="SEAAD_MTG",
                             meta.data = taxonomy.anno,
                             hierarchy = hierarchy,
                             ## --- Optional parameters ---
-                            counts = as(taxonomy.counts, "dgCMatrix"),
+                            counts = taxonomy.counts,
                             normalized.expr = NULL,
                             highly_variable_genes = 1000, ## Select top 1000 binary genes
                             marker_genes = NULL,
@@ -103,8 +99,9 @@ AIT.anndata = buildTaxonomy(title="SEAAD_MTG",
                             ##
                             dend = seaad_dend, ## Pre-computed dendrogram
                             taxonomyDir = getwd(), ## This is where our taxonomy will be created
-							addMapMyCells = TRUE, 
+                            addMapMyCells = TRUE, 
                             ##
+                            add.dendrogram.markers = TRUE,  # Allow tree mapping. Very slow, but required for downstream patch-seq analysis.
                             subsample=100)
 
 ## Check whether the taxonomy file is valid (This happens within buildTaxonomy and is not strictly necessary)
@@ -126,7 +123,6 @@ AIT.anndata = buildTaxonomyMode(AIT.anndata,
                                 highly_variable_genes = 1000,
                                 embeddings = "highly_variable_genes_neurons",
                                 retain.cells = neuron.cells, 
-                                add.dendrogram.markers = TRUE,  # Very slow, but required for downstream patch-seq analysis.
                                 subsample = 100, 
                                 overwrite = TRUE)
 ```

--- a/examples/build_MTG_taxonomy.md
+++ b/examples/build_MTG_taxonomy.md
@@ -4,7 +4,7 @@ In this tutorial we demonstrate how to setup an Allen Institute Taxonomy object 
 
 These data are already QCed and nicely packaged in h5ad (counts and metadata) and an associated dendrogram files. "cluster_label", "subclass_label", and "class_label" correspond to SEA-AD supertype, subclass, and class, respectively, and are used for defining the hierarchy.  
 
-*We strongly encourage running this code within the scrattch docker environment.  This example was created using docker://jeremyinseattle/scrattch:1.1.1 and will likely fail if run using any earlier scrattch versions.*
+*We strongly encourage running this code within the scrattch docker environment.  This example was created using docker://jeremyinseattle/scrattch:1.1.2 and will likely fail if run using any earlier scrattch versions.*
 
 #### Prepare taxonomy data set:
 
@@ -55,7 +55,7 @@ hierarchy = list("class", "subclass", "cluster_id")
 
 ## Identify Ensembl IDs 
 # Common NCBI taxIDs: Human = 9606; Mouse = 10090; Macaque (rhesus) = 9544; Marmoset = 9483
-ensembl_id <- geneSymbolToEnsembl(gene.symbols = rownames(taxonomy.counts), ncbi.taxid = 9606)
+ensembl_id <- geneSymbolToEnsembl(gene.symbols = colnames(taxonomy.counts), ncbi.taxid = 9606)
 
 ## Update the metadata to align with AIT schema
 colnames(taxonomy.metadata)[colnames(taxonomy.metadata)=="cluster"]             = "cluster_id"


### PR DESCRIPTION
## scrattch.taxonomy v1.1.2

Update to allow counts to be provided as cellxgene or genexcell.

### Major changes
* Creation of logCPM_byRows to allow counts to be input as cellxgene or genexcell and to avoid multiple large matrix transpositions
* Update loadTaxonomy to auto-calulate normalized counts so these don't need to be saved in h5ad files
* Addition of a gene.meta.data slot in buildTaxonomy for gene information
* Improve treatment of dendrograms (precomputed dendrograms were being ignored and non-ideal genes were being used to compute)

### Minor changes
* A few additional bug fixes from v1.1.1
* Minor updates to the MTG example 
* Output additional warnings when metadata is changed with updateTaxonomyMetadata
