### PR TITLE
Jeremy1p2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,3 @@ data/*.csv
 examples/build_MTG_patchseq_taxonomy_temp.Rmd
 examples/build_MTG_patchseq_taxonomy_TEMP.Rmd
 examples/patchseq.RData
-
-https://alleninstitute.github.io/scrattch.patchseq/
-https://alleninstitute.github.io/scrattch.mapping/
-https://alleninstitute.github.io/scrattch.taxonomy/

--- a/R/buildTaxonomyMode.R
+++ b/R/buildTaxonomyMode.R
@@ -216,6 +216,7 @@ buildTaxonomyMode = function(AIT.anndata,
   print("===== Writing taxonomy anndata without saved normalized data=====")
   AIT.anndata2 = AIT.anndata
   AIT.anndata2$X = NULL
+  AIT.anndata2$uns$title <- gsub(".h5ad","",AIT.anndata2$uns$title)
   AIT.anndata2$write_h5ad(file.path(AIT.anndata2$uns$taxonomyDir, paste0(AIT.anndata2$uns$title, ".h5ad")))
   rm(AIT.anndata2)
   

--- a/R/buildTaxonomyMode.R
+++ b/R/buildTaxonomyMode.R
@@ -127,6 +127,8 @@ buildTaxonomyMode = function(AIT.anndata,
   
   
   ## MODIFY THE DENDROGRAM AND SAVE IN THE ANNDATA
+  ### -- FUTURE UPDATE: Allow a separate dendrogram to be entered as a variable rather than automatically subsetting the existing dendrogram
+  ### -- FUTURE UPDATE: Allow for non-binary dendrograms
   
   if(!is.null(AIT.anndata$uns$dend)){
     dend = json_to_dend(AIT.anndata$uns$dend[["standard"]])

--- a/R/loadTaxonomy.R
+++ b/R/loadTaxonomy.R
@@ -71,7 +71,7 @@ loadTaxonomy = function(taxonomyDir = getwd(),
   ## Set scrattch.mapping to default standard mapping mode
   AIT.anndata$uns$mode = "standard"
   AIT.anndata$uns$taxonomyDir = taxonomyDir
-  AIT.anndata$uns$title = anndata_file
+  AIT.anndata$uns$title <- gsub(".h5ad","",anndata_file)
 
   ## Return
   return(AIT.anndata)

--- a/R/setupMapMyCells.R
+++ b/R/setupMapMyCells.R
@@ -14,7 +14,7 @@
 #' 
 #' @import anndata
 #'
-#' @return AIT_anndata, a reference taxonomy with hierarchical files, such as precompute stats and query markers saved in uns.
+#' @return AIT_anndata, a reference taxonomy with hierarchical files, such as precomputed stats and query markers saved in uns.
 #'
 #' @export
 addMapMyCells = function(AIT_anndata,
@@ -52,6 +52,12 @@ addMapMyCells = function(AIT_anndata,
 
       # get file path to the AIT taxonomy (h5ad)
       taxonomy_anndata_path = get_anndata_path(AIT_anndata, anndata_path, tmp_dir)
+      
+      ## If counts are included but normalized counts are not, calculate normalized counts     <= OMIT THIS PART IF NORMALIZED COUNTS AREN'T NEEDED
+      if((!is.null(AIT.anndata$raw$X))&(is.null(AIT.anndata$X))){
+        normalized.expr = log2CPM_byRow(AIT.anndata$raw$X)
+        AIT.anndata$X   = normalized.expr 
+      }  # <== End potential omission
       
       # (NEW!) write a subsetted h5ad file to the tmp_dir. This will allow proper subsetting of the compute stats and speed it up.
       if(sum(AIT_anndata$uns$filter[[AIT_anndata$uns$mode]])==0){

--- a/R/setupMapMyCells.R
+++ b/R/setupMapMyCells.R
@@ -126,6 +126,7 @@ addMapMyCells = function(AIT_anndata,
         unlink(mode_dir, recursive = TRUE)
       }
       # Remove any missing empty directories
+      ## Potential future update: wrap function in try catch and delete folder if this function fails before this step
       folder.remove = file.remove(dir()[substr(dir(),1,8)=="tmp_dir_"])
       
       return(AIT_anndata)

--- a/R/setupTree.R
+++ b/R/setupTree.R
@@ -204,6 +204,7 @@ addDendrogramMarkers = function(AIT.anndata,
   ##
   print("Save the dendrogram into .h5ad")
   AIT.anndata$uns$dend[[mode.name]] = toJSON(dend_to_json(reference$dend))
+  AIT.anndata$uns$title <- gsub(".h5ad","",AIT.anndata$uns$title)
   AIT.anndata$write_h5ad(file.path(AIT.anndata$uns$taxonomyDir, paste0(AIT.anndata$uns$title, ".h5ad")))
   
   ##

--- a/R/setupTree.R
+++ b/R/setupTree.R
@@ -73,6 +73,12 @@ addDendrogramMarkers = function(AIT.anndata,
     celltypeColumn = names(hierarchy)[length(hierarchy)][[1]]
   }
   
+  ## If counts are included but normalized counts are not, calculate normalized counts
+  if((!is.null(AIT.anndata$raw$X))&(is.null(AIT.anndata$X))){
+    normalized.expr = log2CPM_byRow(AIT.anndata$raw$X)
+    AIT.anndata$X   = normalized.expr 
+  }
+  
   ##
   if(is.null(AIT.anndata$X)){ stop("No data found in AIT.anndata$X. The full count matrix is required for determining marker genes.") }
 

--- a/R/setupTree.R
+++ b/R/setupTree.R
@@ -19,7 +19,7 @@
 #'
 #' If save.shiny.output=TRUE, the following two values will get saved to the uns:
 #'       `memb.ref`   - matrix indicating how much confusion there is the mapping between each cell all of the nodes in the tree (including all cell types) when comparing clustering and mapping results with various subsamplings of the data
-#'       `map.df.ref` - Result of tree mapping for each cell in the reference against the clustering tree, including various statistics and marker gene evidence.  This is the same output that comes from tree mapping.#'
+#'       `map.df.ref` - Result of tree mapping for each cell in the reference against the clustering tree, including various statistics and marker gene evidence.  This is the same output that comes from tree mapping.
 #' 
 #' @import feather
 #' @import scrattch.hicat
@@ -164,7 +164,7 @@ addDendrogramMarkers = function(AIT.anndata,
     reference$dend = revert_dend_label(reference$dend,get_nodes_attr(reference$dend, "original_label"),"label")
   }
 
-  #print("Save the reference dendrogram for this mode")  # NOTE: we don't need to save thie dendrogram, as it is staved within the AIT file
+  #print("Save the reference dendrogram for this mode")  # NOTE: we don't need to save this dendrogram, as it is saved within the AIT file
   #dend = reference$dend
   #saveRDS(dend, file.path(taxonomyModeDir, "dend.RData"))
   ## Note, this overwrites the initial dendrogram but has slightly different formatting from the read, which could cause issues

--- a/R/utils.R
+++ b/R/utils.R
@@ -207,11 +207,12 @@ updateMarkerGenes = function(AIT.anndata,
 #'
 #' @param meta.data A data.frame with cell metadata
 #' @param cluster_colors A named vector of colors for each cluster
+#' @param sample_identifier the name of the column that contains the sample names. default = "cell_id"
 #' 
 #' @return auto_annotated meta.data
 #'
 #' @keywords internal
-.formatMetadata = function(meta.data, cluster_colors=NULL){
+.formatMetadata = function(meta.data, cluster_colors=NULL, sample_identifier="cell_id"){
 
   print("===== Format metadata table for AIT schema =====")
   ## Check for duplicate columns (e.g., XXXX_label and XXXX together will crash auto_annotate)  # NEW #
@@ -224,7 +225,7 @@ updateMarkerGenes = function(AIT.anndata,
   }
 
   ## Run auto_annotate
-  meta.data = auto_annotate(meta.data, "cell_id")
+  meta.data = auto_annotate(meta.data, sample_identifier)
 
   ## Convert chars and factors to characters (moved to AFTER auto_annotate, so numbers can be assigned in correct order for factors)
   for (col in colnames(meta.data)){ 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -10,6 +10,7 @@ Improvements for mapping and patch-seq for schema.
 * Bug fixes
 * Updated documentation
 * Correct setup for tree mapping (fixes a breaking error)
+* Fix issues with `createShiny` introduced after v0.7
 
 --
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,12 +5,15 @@ Improvements for mapping and patch-seq for schema.
 ### Major changes
 * Allow for direct download and loading of taxonomies from AWS with `loadTaxonomy`
 * Adding html documentation for functions
+* Updated example for Mouse VISp
+* Correct treatment of high variance / marker genes
 
 ### Minor changes
 * Bug fixes
 * Updated documentation
 * Correct setup for tree mapping (fixes a breaking error)
 * Fix issues with `createShiny` introduced after v0.7
+* Remove extra ".h5ad" that was being added to title
 
 --
 

--- a/examples/build_MTG_taxonomy.md
+++ b/examples/build_MTG_taxonomy.md
@@ -4,7 +4,7 @@ In this tutorial we demonstrate how to setup an Allen Institute Taxonomy object 
 
 These data are already QCed and nicely packaged in h5ad (counts and metadata) and an associated dendrogram files. "cluster_label", "subclass_label", and "class_label" correspond to SEA-AD supertype, subclass, and class, respectively, and are used for defining the hierarchy.  
 
-*We strongly encourage running this code within the scrattch docker environment.  This example was created using docker://jeremyinseattle/scrattch:1.1.2 and will likely fail if run using any earlier scrattch versions.*
+*We strongly encourage running this code within the scrattch docker environment.  This example was created using docker://alleninst/scrattch:1.1.2 and will likely fail if run using any earlier scrattch versions.*
 
 #### Prepare taxonomy data set:
 

--- a/examples/build_taxonomy.md
+++ b/examples/build_taxonomy.md
@@ -2,6 +2,8 @@
 
 In this tutorial we demonstrate how to setup an Allen Institute Taxonomy object using scrattch.taxonomy. **WARNING** As written this AIT file will not validate as `MUST` schema elements are missing, we will update this tutorial shortly. When building your own AIT file please carefully adhere to the [schema definitions](https://github.com/AllenInstitute/AllenInstituteTaxonomy/tree/main/schema). In this tutorial we will use prepackaged data from [Tasic et al 2016](https://www.nature.com/articles/nn.4216)
 
+*We strongly encourage running this code within the scrattch docker environment.  This example was created using docker://alleninst/scrattch:1.2 and will likely fail if run using scrattch versions earlier than 1.0.*
+
 #### Required inputs:
 
 * Cell type hierarchy list, from coarse to most granular annotations
@@ -49,7 +51,7 @@ rownames(umap.coords) = colnames(taxonomy.counts)
 
 ## Identify Ensembl IDs 
 # Common NCBI taxIDs: Human = 9606; Mouse = 10090; Macaque (rhesus) = 9544; Marmoset = 9483
-# ensembl_id <- geneSymbolToEnsembl(gene.symbols = rownames(taxonomy.counts), ncbi.taxid = 10090)
+ensembl_id <- geneSymbolToEnsembl(gene.symbols = rownames(taxonomy.counts), ncbi.taxid = 10090)
 
 ## Align taxonomy metadata with AIT standard
 # NOTE: for this particular example, nothing gets updated
@@ -65,7 +67,7 @@ AIT.anndata = buildTaxonomy(title = "Tasic2016",
                             normalized.expr = NULL,
                             highly_variable_genes = NULL,
                             marker_genes = list("marker_genes_binary" = binary.genes),
-                            ensembl_id = NULL,
+                            ensembl_id = ensembl_id,
                             cluster_stats = NULL, ## Pre-computed cluster stats
                             embeddings = list("X_umap" = umap.coords),
                             ##

--- a/man/addDendrogramMarkers.Rd
+++ b/man/addDendrogramMarkers.Rd
@@ -36,7 +36,7 @@ addDendrogramMarkers(
 
 \item{de.param}{Differential expression (DE) parameters for genes and clusters used to define marker genes.  By default the values are set to the 10x nuclei defaults from scrattch.hicat, except with min.cells=2 (see notes below).}
 
-\item{calculate.de.genes}{Default=TRUE. If set to false, the function will search for "de_genes" in a file called "de_genes.RData" in the folder taxonomyDir, and will use those if available.}
+\item{calculate.de.genes}{Default=TRUE. If set to false, the function will search for "de_genes" in a file called "de_genes_\link{mode}.RData" in the folder taxonomyDir, and will use those if available.}
 
 \item{save.shiny.output}{Should standard output files be generated and saved to the AIT file (default=TRUE).  These are not required for tree mapping, but are required for building a patch-seq shiny instance. See notes.}
 
@@ -56,7 +56,7 @@ By default VERY loose parameters are set for de_param in an effort to get extra 
 
 If save.shiny.output=TRUE, the following two values will get saved to the uns:
 \code{memb.ref}   - matrix indicating how much confusion there is the mapping between each cell all of the nodes in the tree (including all cell types) when comparing clustering and mapping results with various subsamplings of the data
-\code{map.df.ref} - Result of tree mapping for each cell in the reference against the clustering tree, including various statistics and marker gene evidence.  This is the same output that comes from tree mapping.#'}
+\code{map.df.ref} - Result of tree mapping for each cell in the reference against the clustering tree, including various statistics and marker gene evidence.  This is the same output that comes from tree mapping.}
 }
 \value{
 An updated dendrogram variable that is the same as \code{dend} except with marker genes added to each node.

--- a/man/addMapMyCells.Rd
+++ b/man/addMapMyCells.Rd
@@ -36,7 +36,7 @@ addMapMyCells(
 \item{user_query_markers_path}{Alternative path to the user provided query markers JSON file. Will be generated, if not provided.}
 }
 \value{
-AIT_anndata, a reference taxonomy with hierarchical files, such as precompute stats and query markers saved in uns.
+AIT_anndata, a reference taxonomy with hierarchical files, such as precomputed stats and query markers saved in uns.
 }
 \description{
 This hierarchical mapping is a wrapper around cell_type_mapper and call's it's functions to generate needed files needed for mapping.

--- a/man/dot-formatMetadata.Rd
+++ b/man/dot-formatMetadata.Rd
@@ -4,12 +4,18 @@
 \alias{.formatMetadata}
 \title{Function to update meta.data}
 \usage{
-.formatMetadata(meta.data, cluster_colors = NULL)
+.formatMetadata(
+  meta.data,
+  cluster_colors = NULL,
+  sample_identifier = "cell_id"
+)
 }
 \arguments{
 \item{meta.data}{A data.frame with cell metadata}
 
 \item{cluster_colors}{A named vector of colors for each cluster}
+
+\item{sample_identifier}{the name of the column that contains the sample names. default = "cell_id"}
 }
 \value{
 auto_annotated meta.data


### PR DESCRIPTION
## scrattch.taxonomy v1.2

Improvements for mapping and patch-seq for schema.  Note this is reflected in docker://jeremyinseattle/scrattch:1.2.1.  I'll move to alleninst once tested.

### Major changes
* Allow for direct download and loading of taxonomies from AWS with `loadTaxonomy`
* Adding html documentation for functions
* Updated example for Mouse VISp
* Correct treatment of high variance / marker genes

### Minor changes
* Bug fixes
* Updated documentation
* Correct setup for tree mapping (fixes a breaking error)
* Fix issues with `createShiny` introduced after v0.7
* Remove extra ".h5ad" that was being added to title
